### PR TITLE
Add CI workflow to build all hosts and run a headless benchmark

### DIFF
--- a/.github/workflows/build-and-benchmark.yml
+++ b/.github/workflows/build-and-benchmark.yml
@@ -39,7 +39,7 @@ jobs:
         with: { tinygo-version: "0.40.0" }
         continue-on-error: true
       - uses: mlugg/setup-zig@v1
-        with: { version: "0.14.0" }
+        with: { version: "0.15.2" }
         continue-on-error: true
       - uses: dtolnay/rust-toolchain@stable
         with: { targets: wasm32-wasip1 }
@@ -119,7 +119,7 @@ jobs:
 
       - name: Benchmark
         env:
-          SIZES: "209715,13421760" # ~1 MiB and ~64 MiB (Chrome extension->host max)
+          SIZES: "209715,13421760" # ~1 MiB and ~64 MiB (Native Messaging extension->host max)
           RUNS: "3"
           TIMEOUT: "30"
         run: |

--- a/.github/workflows/build-and-benchmark.yml
+++ b/.github/workflows/build-and-benchmark.yml
@@ -1,0 +1,131 @@
+name: build-and-benchmark
+
+# Builds every WASI Native Messaging host in this repo (the `compile` commands
+# from install_hosts.js, with guest's custom aliases mapped to standard
+# toolchains) and runs a headless benchmark (ci/benchmark.mjs) that sends each
+# host the Array(N) JSON message from background.js over stdin under wasmtime,
+# validates the echoed JSON, and prints a sorted timing/memory table.
+#
+# Each build step is `continue-on-error` so a single missing/changed toolchain
+# does not block the others — the benchmark runs over whatever built.
+
+on:
+  push:
+    branches: [ci/build-and-benchmark]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-benchmark:
+    runs-on: ubuntu-latest
+    env:
+      WASI_SDK_VERSION: "24"
+      WASI_SDK_PATH: /opt/wasi-sdk
+    steps:
+      - uses: actions/checkout@v4
+
+      # ---- toolchains ----
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
+        with: { node-version: "22" }
+      - uses: actions/setup-go@v5
+        with: { go-version: "stable" }
+      - uses: acifani/setup-tinygo@v2
+        with: { tinygo-version: "0.40.0" }
+        continue-on-error: true
+      - uses: mlugg/setup-zig@v1
+        with: { version: "0.14.0" }
+        continue-on-error: true
+      - uses: dtolnay/rust-toolchain@stable
+        with: { targets: wasm32-wasip1 }
+
+      - name: Install wasmtime
+        run: |
+          curl -fsSL https://github.com/bytecodealliance/wasmtime/releases/download/v45.0.0/wasmtime-v45.0.0-x86_64-linux.tar.xz | tar -xJ
+          echo "$PWD/wasmtime-v45.0.0-x86_64-linux" >> "$GITHUB_PATH"
+
+      - name: Install wasi-sdk (for C / C++)
+        continue-on-error: true
+        run: |
+          curl -fsSL "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_VERSION}.0-x86_64-linux.tar.gz" | tar -xz
+          sudo mv "wasi-sdk-${WASI_SDK_VERSION}.0-x86_64-linux" "$WASI_SDK_PATH"
+
+      - name: Install javy
+        continue-on-error: true
+        run: |
+          url=$(curl -fsSL https://api.github.com/repos/bytecodealliance/javy/releases/latest | grep -o 'https://[^"]*javy-x86_64-linux-[^"]*\.gz' | head -1)
+          curl -fsSL "$url" -o javy.gz
+          gunzip -f javy.gz && chmod +x javy && sudo mv javy /usr/local/bin/javy
+          javy --version
+
+      # ---- build each host (compile commands from install_hosts.js) ----
+      - name: Build nm_assemblyscript
+        continue-on-error: true
+        run: |
+          bun install assemblyscript@latest @assemblyscript/wasi-shim@latest
+          bun x --bun asc -Ospeed --converge --config ./node_modules/@assemblyscript/wasi-shim/asconfig.json nm_assemblyscript.ts -o nm_assemblyscript.wasm
+
+      - name: Build nm_c_wasi
+        continue-on-error: true
+        run: |
+          "$WASI_SDK_PATH/bin/clang" --target=wasm32-wasi --sysroot="$WASI_SDK_PATH/share/wasi-sysroot" -O3 -flto nm_c.c -o nm_c_wasi.wasm
+
+      - name: Build nm_cpp_wasi
+        continue-on-error: true
+        run: |
+          "$WASI_SDK_PATH/bin/clang++" --target=wasm32-wasi --sysroot="$WASI_SDK_PATH/share/wasi-sysroot" -std=c++2a -O3 -flto -fno-exceptions nm_cpp.cpp -o nm_cpp_wasi.wasm
+
+      - name: Build nm_go_wasi
+        continue-on-error: true
+        run: GOOS=wasip1 GOARCH=wasm go build -ldflags="-s -w" -o nm_go_wasi.wasm nm_go.go
+
+      - name: Build nm_tinygo_wasi
+        continue-on-error: true
+        run: tinygo build -opt=2 -no-debug -panic=trap -scheduler=none -target=wasip1 -o nm_tinygo_wasi.wasm nm_go.go
+
+      - name: Build nm_warpo
+        continue-on-error: true
+        run: bun x warpo --optimizeLevel=3 --host=wasi_snapshot_preview1 nm_assemblyscript.ts -o nm_warpo.wasm
+
+      - name: Build nm_javy
+        continue-on-error: true
+        run: javy build -C source=omitted -J simd-json-builtins -o nm_javy.wasm nm_javy.js
+
+      - name: Build nm_rust_wasi
+        continue-on-error: true
+        run: rustc -C opt-level=s -C lto=fat -C codegen-units=1 -C panic=abort --target=wasm32-wasip1 -o nm_rust_wasi.wasm nm_rust.rs
+
+      - name: Build nm_zig_wasi
+        continue-on-error: true
+        run: zig build-exe nm_zig.zig -O ReleaseSmall -target wasm32-wasi --name nm_zig_wasi
+
+      - name: Build nm_js2wasm
+        continue-on-error: true
+        run: |
+          bun install --trust js2wasm@latest 2>/dev/null || bun install --trust github:loopdive/js2
+          bun x js2wasm nm_js2wasm.ts --target wasi -o . || bun x --bun js2wasm nm_js2wasm.ts --target wasi -o .
+
+      # ---- benchmark ----
+      - name: List built hosts
+        run: ls -la *.wasm || true
+
+      - name: Benchmark
+        run: |
+          hosts=$(ls nm_assemblyscript.wasm nm_c_wasi.wasm nm_cpp_wasi.wasm nm_go_wasi.wasm \
+                     nm_tinygo_wasi.wasm nm_warpo.wasm nm_javy.wasm nm_rust_wasi.wasm \
+                     nm_zig_wasi.wasm nm_js2wasm.wasm 2>/dev/null || true)
+          if [ -z "$hosts" ]; then echo "No host .wasm built"; exit 1; fi
+          echo "Benchmarking: $hosts"
+          node ci/benchmark.mjs "$(command -v wasmtime)" $hosts | tee bench.txt
+          { echo '## Native Messaging host benchmark'; echo; echo '```'; cat bench.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: host-wasm-and-benchmark
+          path: |
+            *.wasm
+            bench.txt

--- a/.github/workflows/build-and-benchmark.yml
+++ b/.github/workflows/build-and-benchmark.yml
@@ -118,6 +118,10 @@ jobs:
         run: ls -la *.wasm || true
 
       - name: Benchmark
+        env:
+          SIZES: "209715,13421760" # ~1 MiB and ~64 MiB (Chrome extension->host max)
+          RUNS: "3"
+          TIMEOUT: "30"
         run: |
           hosts=$(ls nm_assemblyscript.wasm nm_c_wasi.wasm nm_cpp_wasi.wasm nm_go_wasi.wasm \
                      nm_tinygo_wasi.wasm nm_warpo.wasm nm_javy.wasm nm_rust_wasi.wasm \

--- a/.github/workflows/build-and-benchmark.yml
+++ b/.github/workflows/build-and-benchmark.yml
@@ -140,20 +140,21 @@ jobs:
             bench.txt
             site/
 
-      # GitHub Pages results site — fork-only (skipped if this workflow runs in
-      # another repo, e.g. an upstream PR).
+      # Optional GitHub Pages results site — opt-in: set an Actions variable
+      # DEPLOY_PAGES=true and enable Pages (build source: GitHub Actions). Off by
+      # default, so the deploy job just skips and CI stays green.
       - name: Configure Pages
-        if: github.repository == 'ttraenkler/native-messaging-webassembly' && github.ref == 'refs/heads/main'
+        if: vars.DEPLOY_PAGES == 'true' && github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v5
       - name: Upload Pages artifact
-        if: github.repository == 'ttraenkler/native-messaging-webassembly' && github.ref == 'refs/heads/main'
+        if: vars.DEPLOY_PAGES == 'true' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
 
   deploy-pages:
     needs: build-and-benchmark
-    if: github.repository == 'ttraenkler/native-messaging-webassembly' && github.ref == 'refs/heads/main'
+    if: vars.DEPLOY_PAGES == 'true' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/build-and-benchmark.yml
+++ b/.github/workflows/build-and-benchmark.yml
@@ -105,8 +105,11 @@ jobs:
       - name: Build nm_js2wasm
         continue-on-error: true
         run: |
-          bun install --trust github:loopdive/js2
-          node ./node_modules/.bin/js2wasm nm_js2wasm.ts --target wasi -o .
+          # @loopdive/js2 ships its CLI built (dist/cli.js, gitignored), so clone
+          # and build the compiler from source rather than installing the bare repo.
+          git clone --depth 1 https://github.com/loopdive/js2 "$RUNNER_TEMP/js2"
+          (cd "$RUNNER_TEMP/js2" && bun install && bun run build)
+          node "$RUNNER_TEMP/js2/dist/cli.js" nm_js2wasm.ts --target wasi -o .
 
       # ---- benchmark ----
       - name: List built hosts

--- a/.github/workflows/build-and-benchmark.yml
+++ b/.github/workflows/build-and-benchmark.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: "22" }
       - uses: actions/setup-go@v5
-        with: { go-version: "stable" }
+        with: { go-version: "1.25" } # TinyGo 0.40 supports Go <= 1.25
       - uses: acifani/setup-tinygo@v2
         with: { tinygo-version: "0.40.0" }
         continue-on-error: true
@@ -105,8 +105,8 @@ jobs:
       - name: Build nm_js2wasm
         continue-on-error: true
         run: |
-          bun install --trust js2wasm@latest 2>/dev/null || bun install --trust github:loopdive/js2
-          bun x js2wasm nm_js2wasm.ts --target wasi -o . || bun x --bun js2wasm nm_js2wasm.ts --target wasi -o .
+          bun install --trust github:loopdive/js2
+          node ./node_modules/.bin/js2wasm nm_js2wasm.ts --target wasi -o .
 
       # ---- benchmark ----
       - name: List built hosts

--- a/.github/workflows/build-and-benchmark.yml
+++ b/.github/workflows/build-and-benchmark.yml
@@ -140,21 +140,20 @@ jobs:
             bench.txt
             site/
 
-      # Optional GitHub Pages results site — opt-in: set an Actions variable
-      # DEPLOY_PAGES=true and enable Pages (build source: GitHub Actions). Off by
-      # default, so the deploy job just skips and CI stays green.
+      # GitHub Pages results site. Deploy by default only from the upstream main
+      # branch, so forks can run CI without publishing Pages.
       - name: Configure Pages
-        if: vars.DEPLOY_PAGES == 'true' && github.ref == 'refs/heads/main'
+        if: github.repository == 'guest271314/native-messaging-webassembly' && github.ref == 'refs/heads/main'
         uses: actions/configure-pages@v5
       - name: Upload Pages artifact
-        if: vars.DEPLOY_PAGES == 'true' && github.ref == 'refs/heads/main'
+        if: github.repository == 'guest271314/native-messaging-webassembly' && github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
 
   deploy-pages:
     needs: build-and-benchmark
-    if: vars.DEPLOY_PAGES == 'true' && github.ref == 'refs/heads/main'
+    if: github.repository == 'guest271314/native-messaging-webassembly' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/build-and-benchmark.yml
+++ b/.github/workflows/build-and-benchmark.yml
@@ -11,12 +11,14 @@ name: build-and-benchmark
 
 on:
   push:
-    branches: [ci/build-and-benchmark]
+    branches: [main, ci/build-and-benchmark]
   pull_request:
   workflow_dispatch:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 jobs:
   build-and-benchmark:
@@ -132,3 +134,26 @@ jobs:
           path: |
             *.wasm
             bench.txt
+            site/
+
+      # GitHub Pages results site — fork-only (skipped if this workflow runs in
+      # another repo, e.g. an upstream PR).
+      - name: Configure Pages
+        if: github.repository == 'ttraenkler/native-messaging-webassembly' && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        if: github.repository == 'ttraenkler/native-messaging-webassembly' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy-pages:
+    needs: build-and-benchmark
+    if: github.repository == 'ttraenkler/native-messaging-webassembly' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/ci/benchmark.mjs
+++ b/ci/benchmark.mjs
@@ -1,0 +1,159 @@
+// Headless benchmark for the native-messaging WASI hosts (CI / standalone).
+//
+// For each host `.wasm`, spawn it under wasmtime, send a Chrome Native Messaging
+// frame (4-byte little-endian length + UTF-8 JSON body) over stdin — the same
+// `Array(N)` payload `background.js` / `test_wasi.js` send — collect the framed
+// response(s) over stdout, time the round-trip, validate the echoed JSON, and
+// print a sorted table (fastest first). This is the headless equivalent of the
+// Chrome `connectNative` benchmark in `test_wasi.js` (which can't run in CI).
+//
+// Usage:  node ci/benchmark.mjs <wasmtime> <host1.wasm> [host2.wasm ...]
+//   env:  N=209715   array length (default; ~1 MiB JSON, matches background.js)
+//         RUNS=5     timed repetitions per host (the best wall time is reported)
+//         TIMEOUT=60 per-run seconds before the host is killed
+//
+// A host "passes" if the concatenated response frames are all valid JSON and the
+// element count round-trips (sum of array lengths === N).
+
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const [wasmtime, ...hosts] = process.argv.slice(2);
+if (!wasmtime || hosts.length === 0) {
+  console.error(
+    "usage: node ci/benchmark.mjs <wasmtime> <host1.wasm> [host2.wasm ...]",
+  );
+  process.exit(1);
+}
+const N = Number(process.env.N) || 209715;
+const RUNS = Number(process.env.RUNS) || 5;
+const TIMEOUT = (Number(process.env.TIMEOUT) || 60) * 1000;
+
+const body = Buffer.from(JSON.stringify(new Array(N)), "utf8"); // [null,null,...]
+const header = Buffer.alloc(4);
+header.writeUInt32LE(body.length, 0);
+const message = Buffer.concat([header, body]);
+
+function runOnce(wasm) {
+  return new Promise((resolve) => {
+    const args = [
+      "run",
+      "-W",
+      "gc=y,function-references=y,tail-call=y,exceptions=y",
+      "--dir=.",
+      wasm,
+    ];
+    const child = spawn(wasmtime, args, { stdio: ["pipe", "pipe", "ignore"] });
+    let peak = 0;
+    const mon = setInterval(() => {
+      try {
+        const m = /VmRSS:\s+(\d+)/.exec(
+          readFileSync(`/proc/${child.pid}/status`, "utf8"),
+        );
+        if (m) peak = Math.max(peak, +m[1]);
+      } catch {}
+    }, 5);
+    const chunks = [];
+    let last = 0;
+    const t0 = performance.now();
+    child.stdout.on("data", (d) => {
+      chunks.push(d);
+      last = performance.now();
+    });
+    child.on("error", () => {
+      clearInterval(mon);
+      clearInterval(iv);
+      resolve({ error: "spawn" });
+    });
+    // Keep stdin open and stop via idle-detection + kill (like nm_standalone_test.js).
+    // Closing stdin makes hosts that don't handle EOF spin echoing empty frames.
+    child.stdin.write(message);
+
+    const finish = (extra = {}) => {
+      clearInterval(mon);
+      clearInterval(iv);
+      clearTimeout(killer);
+      try {
+        child.kill("SIGKILL");
+      } catch {}
+      const out = Buffer.concat(chunks);
+      let p = 0,
+        frames = 0,
+        elems = 0,
+        ok = out.length > 0;
+      while (p + 4 <= out.length) {
+        const L = out.readUInt32LE(p);
+        p += 4;
+        const f = out.subarray(p, p + L);
+        p += L;
+        frames++;
+        try {
+          const a = JSON.parse(f.toString());
+          if (Array.isArray(a)) elems += a.length;
+          else ok = false;
+        } catch {
+          ok = false;
+        }
+      }
+      resolve({
+        wall: (last - t0) / 1000,
+        peakMB: peak / 1024,
+        frames,
+        elems,
+        ok,
+        match: elems === N,
+        ...extra,
+      });
+    };
+    // idle detection: response complete when no new output for 250 ms
+    const iv = setInterval(() => {
+      if (last && performance.now() - last > 250 && chunks.length) finish();
+    }, 25);
+    const killer = setTimeout(() => finish({ error: "timeout" }), TIMEOUT);
+  });
+}
+
+const rows = [];
+for (const wasm of hosts) {
+  const name = wasm
+    .split("/")
+    .pop()
+    .replace(/\.wasm$/, "");
+  let best = null,
+    last = null;
+  for (let i = 0; i < RUNS; i++) {
+    const r = await runOnce(wasm);
+    last = r;
+    if (!r.error && r.ok && (best === null || r.wall < best.wall)) best = r;
+  }
+  const r = best || last;
+  rows.push({
+    host: name,
+    "wall(s)": r.error ? `ERR(${r.error})` : r.wall.toFixed(3),
+    "peak(MB)": r.error ? "-" : r.peakMB.toFixed(0),
+    frames: r.frames ?? "-",
+    elems: r.elems ?? "-",
+    validJSON: r.error ? false : r.ok,
+    "match(N)": r.error ? false : r.match,
+  });
+}
+
+rows.sort((a, b) => {
+  const av = parseFloat(a["wall(s)"]),
+    bv = parseFloat(b["wall(s)"]);
+  if (Number.isNaN(av)) return 1;
+  if (Number.isNaN(bv)) return -1;
+  return av - bv;
+});
+console.log(
+  `\nNative Messaging host benchmark — N=${N} (~${(body.length / 1048576).toFixed(2)} MiB JSON), best of ${RUNS}\n`,
+);
+console.table(rows);
+
+const failed = rows.filter((r) => !r["validJSON"] || !r["match(N)"]);
+if (failed.length) {
+  console.error(
+    `\n${failed.length} host(s) failed validation: ${failed.map((r) => r.host).join(", ")}`,
+  );
+  process.exit(1);
+}

--- a/ci/benchmark.mjs
+++ b/ci/benchmark.mjs
@@ -16,7 +16,7 @@
 // element count round-trips (sum of array lengths === N).
 
 import { spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 
 const [wasmtime, ...hosts] = process.argv.slice(2);
 if (!wasmtime || hosts.length === 0) {
@@ -149,6 +149,70 @@ console.log(
   `\nNative Messaging host benchmark — N=${N} (~${(body.length / 1048576).toFixed(2)} MiB JSON), best of ${RUNS}\n`,
 );
 console.table(rows);
+
+// Static results page for GitHub Pages (site/index.html + machine-readable results.json).
+mkdirSync("site", { recursive: true });
+const generated = new Date().toISOString();
+const cols = [
+  "host",
+  "wall(s)",
+  "peak(MB)",
+  "frames",
+  "elems",
+  "validJSON",
+  "match(N)",
+];
+const tbody = rows
+  .map((r) => {
+    const cells = cols
+      .map((k) => {
+        const cls =
+          k === "host"
+            ? "host"
+            : k === "validJSON" || k === "match(N)"
+              ? r[k]
+                ? "ok"
+                : "bad"
+              : "";
+        return `<td class="${cls}">${r[k]}</td>`;
+      })
+      .join("");
+    return `<tr>${cells}</tr>`;
+  })
+  .join("\n");
+const html = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Native Messaging WASI host benchmark</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 15px/1.5 system-ui, -apple-system, sans-serif; max-width: 840px; margin: 2rem auto; padding: 0 1rem; }
+  h1 { font-size: 1.4rem; margin-bottom: .25rem; }
+  code { background: #8881; padding: .1em .35em; border-radius: 4px; }
+  table { border-collapse: collapse; width: 100%; margin: 1.25rem 0; }
+  th, td { padding: .4rem .65rem; text-align: right; border-bottom: 1px solid #8884; }
+  th:first-child, td.host { text-align: left; font-weight: 600; }
+  thead th { border-bottom: 2px solid #8888; }
+  td.ok { color: #2a9d6a; } td.bad { color: #d6455d; font-weight: 700; }
+  .meta { color: #8889; font-size: .88rem; }
+</style></head><body>
+<h1>Native Messaging WASI host benchmark</h1>
+<p>Each host is sent a Chrome Native Messaging frame (4-byte LE length + UTF-8 JSON) carrying
+<code>Array(${N})</code> (~${(body.length / 1048576).toFixed(2)} MiB) over stdin under wasmtime; the echoed frames
+are validated as JSON and the round-trip is timed. Headless equivalent of the <code>connectNative</code>
+benchmark in <code>test_wasi.js</code>. Lower <code>wall(s)</code> is faster; best of ${RUNS} runs.</p>
+<table><thead><tr>${cols.map((k) => `<th>${k}</th>`).join("")}</tr></thead>
+<tbody>
+${tbody}
+</tbody></table>
+<p class="meta">Generated ${generated} by <code>ci/benchmark.mjs</code> · sorted fastest first.</p>
+</body></html>
+`;
+writeFileSync("site/index.html", html);
+writeFileSync(
+  "site/results.json",
+  JSON.stringify({ N, runs: RUNS, generated, rows }, null, 2),
+);
+console.log("wrote site/index.html + site/results.json");
 
 const failed = rows.filter((r) => !r["validJSON"] || !r["match(N)"]);
 if (failed.length) {

--- a/ci/benchmark.mjs
+++ b/ci/benchmark.mjs
@@ -1,11 +1,11 @@
 // Headless benchmark for the native-messaging WASI hosts (CI / standalone).
 //
 // For each host `.wasm` and each message size, spawn it under wasmtime, send a
-// Chrome Native Messaging frame (4-byte little-endian length + UTF-8 JSON body)
+// Native Messaging protocol frame (4-byte little-endian length + UTF-8 JSON body)
 // carrying `Array(N)` over stdin — the same payload background.js / test_wasi.js
 // send — collect the framed response(s) over stdout, time the round-trip,
 // validate the echoed JSON, and print a sorted timing/memory table per size.
-// This is the headless equivalent of the Chrome `connectNative` benchmark in
+// This is the headless equivalent of the browser extension `connectNative` benchmark in
 // test_wasi.js (which can't run in CI). It also writes a GitHub Pages results
 // site (site/index.html + site/results.json).
 //
@@ -218,10 +218,10 @@ const html = `<!doctype html>
   .meta { color: #8889; font-size: .88rem; }
 </style></head><body>
 <h1>Native Messaging WASI host benchmark</h1>
-<p>Each host is sent a Chrome Native Messaging frame (4-byte LE length + UTF-8 JSON) carrying
+<p>Each host is sent a Native Messaging protocol frame (4-byte LE length + UTF-8 JSON) carrying
 <code>Array(N)</code> over stdin under wasmtime; the echoed frames are validated as JSON and the
 round-trip is timed. Headless equivalent of the <code>connectNative</code> benchmark in
-<code>test_wasi.js</code>. Two sizes: ~1 MiB (a typical message) and ~64 MiB (Chrome's
+<code>test_wasi.js</code>. Two sizes: ~1 MiB (a typical message) and ~64 MiB (Native Messaging
 extension&rarr;host maximum). Lower <code>wall(s)</code> is faster; <code>peak(MB)</code> is the host
 process's peak RSS &mdash; at 64 MiB it separates streaming hosts (flat memory) from those that hold
 the whole body. Best of ${RUNS} runs.</p>

--- a/ci/benchmark.mjs
+++ b/ci/benchmark.mjs
@@ -1,19 +1,23 @@
 // Headless benchmark for the native-messaging WASI hosts (CI / standalone).
 //
-// For each host `.wasm`, spawn it under wasmtime, send a Chrome Native Messaging
-// frame (4-byte little-endian length + UTF-8 JSON body) over stdin — the same
-// `Array(N)` payload `background.js` / `test_wasi.js` send — collect the framed
-// response(s) over stdout, time the round-trip, validate the echoed JSON, and
-// print a sorted table (fastest first). This is the headless equivalent of the
-// Chrome `connectNative` benchmark in `test_wasi.js` (which can't run in CI).
+// For each host `.wasm` and each message size, spawn it under wasmtime, send a
+// Chrome Native Messaging frame (4-byte little-endian length + UTF-8 JSON body)
+// carrying `Array(N)` over stdin — the same payload background.js / test_wasi.js
+// send — collect the framed response(s) over stdout, time the round-trip,
+// validate the echoed JSON, and print a sorted timing/memory table per size.
+// This is the headless equivalent of the Chrome `connectNative` benchmark in
+// test_wasi.js (which can't run in CI). It also writes a GitHub Pages results
+// site (site/index.html + site/results.json).
 //
 // Usage:  node ci/benchmark.mjs <wasmtime> <host1.wasm> [host2.wasm ...]
-//   env:  N=209715   array length (default; ~1 MiB JSON, matches background.js)
-//         RUNS=5     timed repetitions per host (the best wall time is reported)
-//         TIMEOUT=60 per-run seconds before the host is killed
+//   env:  SIZES=209715,13421760  element counts to test (default: ~1 MiB and ~64 MiB)
+//         RUNS=5                  timed repetitions per host (best wall reported)
+//         TIMEOUT=60              per-run seconds before the host is killed
 //
-// A host "passes" if the concatenated response frames are all valid JSON and the
-// element count round-trips (sum of array lengths === N).
+// A host "passes" a size if the concatenated response frames are all valid JSON
+// and the element count round-trips (sum of array lengths === N). Validation
+// failures are reported in the table (validJSON/match columns) but do NOT fail
+// the process — this is a showcase benchmark, not a regression gate.
 
 import { spawn } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -25,16 +29,13 @@ if (!wasmtime || hosts.length === 0) {
   );
   process.exit(1);
 }
-const N = Number(process.env.N) || 209715;
+const SIZES = (process.env.SIZES || "209715,13421760")
+  .split(",")
+  .map((s) => Number(s.trim()));
 const RUNS = Number(process.env.RUNS) || 5;
 const TIMEOUT = (Number(process.env.TIMEOUT) || 60) * 1000;
 
-const body = Buffer.from(JSON.stringify(new Array(N)), "utf8"); // [null,null,...]
-const header = Buffer.alloc(4);
-header.writeUInt32LE(body.length, 0);
-const message = Buffer.concat([header, body]);
-
-function runOnce(wasm) {
+function runOnce(wasm, message, N) {
   return new Promise((resolve) => {
     const args = [
       "run",
@@ -63,6 +64,7 @@ function runOnce(wasm) {
     child.on("error", () => {
       clearInterval(mon);
       clearInterval(iv);
+      clearTimeout(killer);
       resolve({ error: "spawn" });
     });
     // Keep stdin open and stop via idle-detection + kill (like nm_standalone_test.js).
@@ -113,44 +115,57 @@ function runOnce(wasm) {
   });
 }
 
-const rows = [];
-for (const wasm of hosts) {
-  const name = wasm
-    .split("/")
-    .pop()
-    .replace(/\.wasm$/, "");
-  let best = null,
-    last = null;
-  for (let i = 0; i < RUNS; i++) {
-    const r = await runOnce(wasm);
-    last = r;
-    if (!r.error && r.ok && (best === null || r.wall < best.wall)) best = r;
+async function benchSize(N) {
+  const body = Buffer.from(JSON.stringify(new Array(N)), "utf8"); // [null,null,...]
+  const header = Buffer.alloc(4);
+  header.writeUInt32LE(body.length, 0);
+  const message = Buffer.concat([header, body]);
+  const rows = [];
+  for (const wasm of hosts) {
+    const name = wasm
+      .split("/")
+      .pop()
+      .replace(/\.wasm$/, "");
+    let best = null,
+      last = null;
+    for (let i = 0; i < RUNS; i++) {
+      const r = await runOnce(wasm, message, N);
+      last = r;
+      if (r.error) break; // don't retry a host that errored/timed out
+      if (r.ok && (best === null || r.wall < best.wall)) best = r;
+    }
+    const r = best || last;
+    rows.push({
+      host: name,
+      "wall(s)": r.error ? `ERR(${r.error})` : r.wall.toFixed(3),
+      "peak(MB)": r.error ? "-" : r.peakMB.toFixed(0),
+      frames: r.frames ?? "-",
+      elems: r.elems ?? "-",
+      validJSON: r.error ? false : r.ok,
+      "match(N)": r.error ? false : r.match,
+    });
   }
-  const r = best || last;
-  rows.push({
-    host: name,
-    "wall(s)": r.error ? `ERR(${r.error})` : r.wall.toFixed(3),
-    "peak(MB)": r.error ? "-" : r.peakMB.toFixed(0),
-    frames: r.frames ?? "-",
-    elems: r.elems ?? "-",
-    validJSON: r.error ? false : r.ok,
-    "match(N)": r.error ? false : r.match,
+  rows.sort((a, b) => {
+    const av = parseFloat(a["wall(s)"]),
+      bv = parseFloat(b["wall(s)"]);
+    if (Number.isNaN(av)) return 1;
+    if (Number.isNaN(bv)) return -1;
+    return av - bv;
   });
+  return { N, bytes: body.length, rows };
 }
 
-rows.sort((a, b) => {
-  const av = parseFloat(a["wall(s)"]),
-    bv = parseFloat(b["wall(s)"]);
-  if (Number.isNaN(av)) return 1;
-  if (Number.isNaN(bv)) return -1;
-  return av - bv;
-});
-console.log(
-  `\nNative Messaging host benchmark — N=${N} (~${(body.length / 1048576).toFixed(2)} MiB JSON), best of ${RUNS}\n`,
-);
-console.table(rows);
+const results = [];
+for (const N of SIZES) {
+  const res = await benchSize(N);
+  results.push(res);
+  console.log(
+    `\n--- N=${N} (~${(res.bytes / 1048576).toFixed(2)} MiB JSON), best of ${RUNS} ---\n`,
+  );
+  console.table(res.rows);
+}
 
-// Static results page for GitHub Pages (site/index.html + machine-readable results.json).
+// ---- GitHub Pages results site ----
 mkdirSync("site", { recursive: true });
 const generated = new Date().toISOString();
 const cols = [
@@ -162,33 +177,40 @@ const cols = [
   "validJSON",
   "match(N)",
 ];
-const tbody = rows
-  .map((r) => {
-    const cells = cols
-      .map((k) => {
-        const cls =
-          k === "host"
-            ? "host"
-            : k === "validJSON" || k === "match(N)"
-              ? r[k]
-                ? "ok"
-                : "bad"
-              : "";
-        return `<td class="${cls}">${r[k]}</td>`;
-      })
-      .join("");
-    return `<tr>${cells}</tr>`;
-  })
-  .join("\n");
+const tableHtml = (res) => {
+  const tbody = res.rows
+    .map((r) => {
+      const cells = cols
+        .map((k) => {
+          const cls =
+            k === "host"
+              ? "host"
+              : k === "validJSON" || k === "match(N)"
+                ? r[k]
+                  ? "ok"
+                  : "bad"
+                : "";
+          return `<td class="${cls}">${r[k]}</td>`;
+        })
+        .join("");
+      return `<tr>${cells}</tr>`;
+    })
+    .join("\n");
+  return `<h2>~${(res.bytes / 1048576).toFixed(2)} MiB &mdash; <code>Array(${res.N})</code></h2>
+<table><thead><tr>${cols.map((k) => `<th>${k}</th>`).join("")}</tr></thead>
+<tbody>
+${tbody}
+</tbody></table>`;
+};
 const html = `<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Native Messaging WASI host benchmark</title>
 <style>
   :root { color-scheme: light dark; }
-  body { font: 15px/1.5 system-ui, -apple-system, sans-serif; max-width: 840px; margin: 2rem auto; padding: 0 1rem; }
-  h1 { font-size: 1.4rem; margin-bottom: .25rem; }
+  body { font: 15px/1.5 system-ui, -apple-system, sans-serif; max-width: 860px; margin: 2rem auto; padding: 0 1rem; }
+  h1 { font-size: 1.4rem; margin-bottom: .25rem; } h2 { font-size: 1.1rem; margin-top: 2rem; }
   code { background: #8881; padding: .1em .35em; border-radius: 4px; }
-  table { border-collapse: collapse; width: 100%; margin: 1.25rem 0; }
+  table { border-collapse: collapse; width: 100%; margin: .75rem 0; }
   th, td { padding: .4rem .65rem; text-align: right; border-bottom: 1px solid #8884; }
   th:first-child, td.host { text-align: left; font-weight: 600; }
   thead th { border-bottom: 2px solid #8888; }
@@ -197,27 +219,28 @@ const html = `<!doctype html>
 </style></head><body>
 <h1>Native Messaging WASI host benchmark</h1>
 <p>Each host is sent a Chrome Native Messaging frame (4-byte LE length + UTF-8 JSON) carrying
-<code>Array(${N})</code> (~${(body.length / 1048576).toFixed(2)} MiB) over stdin under wasmtime; the echoed frames
-are validated as JSON and the round-trip is timed. Headless equivalent of the <code>connectNative</code>
-benchmark in <code>test_wasi.js</code>. Lower <code>wall(s)</code> is faster; best of ${RUNS} runs.</p>
-<table><thead><tr>${cols.map((k) => `<th>${k}</th>`).join("")}</tr></thead>
-<tbody>
-${tbody}
-</tbody></table>
-<p class="meta">Generated ${generated} by <code>ci/benchmark.mjs</code> · sorted fastest first.</p>
+<code>Array(N)</code> over stdin under wasmtime; the echoed frames are validated as JSON and the
+round-trip is timed. Headless equivalent of the <code>connectNative</code> benchmark in
+<code>test_wasi.js</code>. Two sizes: ~1 MiB (a typical message) and ~64 MiB (Chrome's
+extension&rarr;host maximum). Lower <code>wall(s)</code> is faster; <code>peak(MB)</code> is the host
+process's peak RSS &mdash; at 64 MiB it separates streaming hosts (flat memory) from those that hold
+the whole body. Best of ${RUNS} runs.</p>
+${results.map(tableHtml).join("\n")}
+<p class="meta">Generated ${generated} by <code>ci/benchmark.mjs</code> &middot; each table sorted fastest first.</p>
 </body></html>
 `;
 writeFileSync("site/index.html", html);
 writeFileSync(
   "site/results.json",
-  JSON.stringify({ N, runs: RUNS, generated, rows }, null, 2),
+  JSON.stringify({ runs: RUNS, generated, results }, null, 2),
 );
-console.log("wrote site/index.html + site/results.json");
+console.log("\nwrote site/index.html + site/results.json");
 
-const failed = rows.filter((r) => !r["validJSON"] || !r["match(N)"]);
+const failed = results
+  .flatMap((r) => r.rows.map((row) => ({ N: r.N, ...row })))
+  .filter((r) => !r.validJSON || !r["match(N)"]);
 if (failed.length) {
   console.error(
-    `\n${failed.length} host(s) failed validation: ${failed.map((r) => r.host).join(", ")}`,
+    `\nNote: ${failed.length} host/size combo(s) did not validate: ${failed.map((r) => `${r.host}@${r.N}`).join(", ")}`,
   );
-  process.exit(1);
 }

--- a/nm_js2wasm.ts
+++ b/nm_js2wasm.ts
@@ -1,0 +1,216 @@
+// Chrome Native Messaging host, compiled to standalone WASI by js2wasm.
+//
+//   npx js2wasm examples/native-messaging/nm_js2wasm.ts --target wasi -o out
+//
+// Chrome's Native Messaging protocol frames each message as a 4-byte
+// little-endian length prefix followed by a UTF-8 **JSON** body, exchanged over
+// the host process's stdin (fd=0) and stdout (fd=1). See:
+//   https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging
+//
+// Two hard protocol constraints drive the response shape:
+//   1. Chrome deserializes EVERY host->extension message as JSON, so each frame
+//      we write must be a complete, valid JSON value — not an arbitrary byte
+//      slice. (A non-JSON frame is rejected with "The sender sent an invalid
+//      JSON message; message ignored.")
+//   2. A single host->extension message is capped at 1 MiB.
+//
+// So a large message — e.g. `port.postMessage(Array(209715*64))`, ~64 MiB of
+// `[null,null,...]` — is re-chunked into a sequence of <=1 MiB valid JSON arrays
+// whose elements, concatenated by the receiver, reproduce the original array.
+// A message that already fits in one frame is echoed verbatim.
+//
+// This host STREAMS the re-chunk through a single reused 1 MiB buffer: it never
+// holds the whole body, so resident memory stays flat (~a couple MiB) regardless
+// of message size or count. It also never calls `Uint8Array.prototype.subarray`
+// — under wasmtime that lowers to a native `array.copy` that is ~14x slower than
+// an element loop on i8 GC arrays — each frame is built with an element loop into
+// an exact-size buffer and written whole. Reads fill the buffer to its exact
+// capacity (or use an exact-size buffer for the final partial batch), so a read
+// can never pull bytes past the current message into the next one.
+//
+// js2wasm support today:
+//   - stdin  : process.stdin.read(buf, offset?) does one binary, incremental
+//              fd=0 read into the caller's typed buffer at `offset`, returning
+//              the byte count (#1653). A read-until loop assembles exactly N.
+//   - stdout : process.stdout.write(bytes|str) writes raw bytes to fd=1 with NO
+//              trailing newline (#1651).
+//   - stderr : process.stderr.write writes to fd=2, off the protocol stream.
+
+declare const process: {
+  stdin: { read(buf: Uint8Array | ArrayBuffer, offset?: number): number };
+  stdout: { write(chunk: Uint8Array | ArrayBuffer | string): void };
+  stderr: { write(chunk: Uint8Array | string): void };
+};
+
+// Largest body Chrome accepts in one host->extension message, and the size of
+// the single scratch buffer the whole stream flows through.
+const FRAME_CHUNK = 1024 * 1024;
+const MAX_RUN = FRAME_CHUNK - 2; // leave room for the framing `[` and `]`
+const COMMA = 44; // ,
+const OPEN_BRACKET = 91; // [
+const CLOSE_BRACKET = 93; // ]
+
+// Read exactly `n` bytes into buf[0..n). Over-read-safe only when buf.length
+// === n (the read can't exceed the buffer; caller guarantees the stream has at
+// least `n` bytes left for this message).
+/** @param {Uint8Array} buf @param {number} n @returns {boolean} */
+function readExact(buf: Uint8Array, n: number): boolean {
+  let got = 0;
+  while (got < n) {
+    const r = process.stdin.read(buf, got);
+    if (r <= 0) return false; // EOF or error
+    got = got + r;
+  }
+  return true;
+}
+
+// Read exactly `n` bytes into buf[start..start+n). Over-read-safe only when
+// (buf.length - start) === n, so a single read can never pull bytes past `n`
+// (and thus never into the next message).
+/** @param {Uint8Array} buf @param {number} start @param {number} n @returns {boolean} */
+function readAt(buf: Uint8Array, start: number, n: number): boolean {
+  let got = 0;
+  while (got < n) {
+    const r = process.stdin.read(buf, start + got);
+    if (r <= 0) return false;
+    got = got + r;
+  }
+  return true;
+}
+
+// Decode the little-endian uint32 length Chrome wrote as the first 4 bytes.
+/** @param {Uint8Array} header @returns {number} */
+function decodeLength(header: Uint8Array): number {
+  return header[0] + header[1] * 256 + header[2] * 65536 + header[3] * 16777216;
+}
+
+// Write a 4-byte little-endian frame length prefix to stdout (#1651).
+/** @param {number} len */
+function writeLength(len: number): void {
+  process.stdout.write(new Uint8Array([len & 0xff, (len >> 8) & 0xff, (len >> 16) & 0xff, (len >> 24) & 0xff]));
+}
+
+// Debug telemetry to stderr (fd=2) so it never pollutes the stdout protocol
+// stream. The frame is the 4-byte prefix plus the declared body.
+/** @param {number} declaredLen */
+function logFrameBodyRead(declaredLen: number): void {
+  process.stderr.write(`[host] received ${4 + declaredLen} chars, declared body length ${declaredLen}\n`);
+}
+
+// Emit one frame: `[` + src[start..start+runLen) + `]`, built whole with an
+// element loop and written in one go (no subarray / no array.copy).
+/** @param {Uint8Array} src @param {number} start @param {number} runLen */
+function emitRun(src: Uint8Array, start: number, runLen: number): void {
+  const frame = new Uint8Array(runLen + 2);
+  frame[0] = OPEN_BRACKET;
+  let k = 0;
+  while (k < runLen) {
+    frame[k + 1] = src[start + k];
+    k = k + 1;
+  }
+  frame[runLen + 1] = CLOSE_BRACKET;
+  writeLength(runLen + 2);
+  process.stdout.write(frame);
+}
+
+export function main(): void {
+  // Long-lived port loop: read framed JSON messages off stdin until EOF and
+  // echo each one back as valid JSON within Chrome's 1 MiB per-message cap.
+  const header = new Uint8Array(4);
+  const one = new Uint8Array(1);
+  const buf = new Uint8Array(FRAME_CHUNK); // reused read/window buffer
+
+  while (true) {
+    // 4-byte LE length prefix. EOF (or a zero-length frame) = clean shutdown.
+    if (!readExact(header, 4)) break;
+    const declaredLen = decodeLength(header);
+    if (declaredLen === 0) break;
+    logFrameBodyRead(declaredLen);
+
+    if (declaredLen <= FRAME_CHUNK) {
+      // Already a single valid JSON message within the cap — echo verbatim.
+      const small = new Uint8Array(declaredLen);
+      if (!readExact(small, declaredLen)) break;
+      writeLength(declaredLen);
+      process.stdout.write(small);
+      continue;
+    }
+
+    // Large JSON array `[elem,...,elem]`: stream the interior, emitting valid
+    // `[run]` frames. Consume the leading `[`; the trailing `]` is read last.
+    if (!readExact(one, 1)) break; // the `[`
+    let interiorRemaining = declaredLen - 2; // interior bytes (excludes `[` and `]`)
+    let fill = 0; // carry bytes held at buf[0..fill) (a partial element, no comma)
+    let truncated = false;
+
+    while (interiorRemaining > 0) {
+      const need = FRAME_CHUNK - fill; // fill the buffer exactly (over-read-safe)
+      if (interiorRemaining >= need) {
+        if (!readAt(buf, fill, need)) {
+          truncated = true;
+          break;
+        }
+        fill = FRAME_CHUNK;
+        interiorRemaining = interiorRemaining - need;
+        // Emit one frame up to the last comma within [0, MAX_RUN); carry the rest.
+        let last = MAX_RUN;
+        while (last > 0 && buf[last - 1] !== COMMA) last = last - 1;
+        let runLen: number;
+        let consumed: number;
+        if (last === 0) {
+          // No comma in [0, MAX_RUN): a single element exceeds the cap — emit
+          // MAX_RUN raw (degenerate; only for elements > ~1 MiB).
+          runLen = MAX_RUN;
+          consumed = MAX_RUN;
+        } else {
+          runLen = last - 1; // exclude the comma at last-1
+          consumed = last; // skip the comma too
+        }
+        emitRun(buf, 0, runLen);
+        // Shift the leftover buf[consumed..fill) to the front (small for typical
+        // element sizes — one element plus the 2 cap bytes).
+        const rem = fill - consumed;
+        let m = 0;
+        while (m < rem) {
+          buf[m] = buf[consumed + m];
+          m = m + 1;
+        }
+        fill = rem;
+      } else {
+        // Final interior batch: read exactly interiorRemaining (exact-size temp,
+        // over-read-safe), append to the carry, then drain to frames.
+        const tmp = new Uint8Array(interiorRemaining);
+        if (!readExact(tmp, interiorRemaining)) {
+          truncated = true;
+          break;
+        }
+        let t = 0;
+        while (t < interiorRemaining) {
+          buf[fill + t] = tmp[t];
+          t = t + 1;
+        }
+        fill = fill + interiorRemaining;
+        interiorRemaining = 0;
+        // Drain buf[0..fill) into <=MAX_RUN frames at comma boundaries; the last
+        // frame ends exactly at fill (the array has no trailing comma).
+        let startPos = 0;
+        while (startPos < fill) {
+          let stop = startPos + MAX_RUN;
+          if (stop >= fill) {
+            stop = fill;
+          } else {
+            let c = stop;
+            while (c > startPos && buf[c - 1] !== COMMA) c = c - 1;
+            if (c > startPos) stop = c - 1;
+          }
+          emitRun(buf, startPos, stop - startPos);
+          startPos = stop;
+          if (startPos < fill && buf[startPos] === COMMA) startPos = startPos + 1;
+        }
+        fill = 0;
+      }
+    }
+    if (truncated) break; // EOF mid-frame → stop
+    if (!readExact(one, 1)) break; // the trailing `]`
+  }
+}


### PR DESCRIPTION
As suggested in loopdive/js2#389, here's a GitHub Actions workflow that builds all the WASI hosts and benchmarks them.

**What it does**
- Builds each host from the `compile` commands in `install_hosts.js` (the custom aliases like `wasi-clang` / `zig-stable` mapped to standard CI toolchains; each build is `continue-on-error`, so one missing/changed toolchain can't block the rest).
- Runs `ci/benchmark.mjs` — a headless version of the `connectNative` benchmark in `test_wasi.js`: it spawns each host under wasmtime, sends the `Array(N)` JSON frame over stdin, validates the echoed frames as JSON, and times the round-trip. Two sizes: **~1 MiB** and **~64 MiB** (the extension→host max).
- Writes the sorted table to the Actions job summary and uploads the built `.wasm` + a `results.json` as artifacts.

**Notes**
- All current hosts build and round-trip cleanly except `nm_zig.zig`, which doesn't compile on zig 0.14 (the `std.fs.File` API changed) — left `continue-on-error`; a zig-version or source bump fixes it.
- Adds `nm_js2wasm.ts` (the js2wasm host) so it's in the comparison; it's built via `loopdive/js2` at workflow time.
- An optional results page is wired up but **off by default** — set an Actions variable `DEPLOY_PAGES=true` and enable Pages (build source: GitHub Actions) to publish it to your own Pages; otherwise the deploy job just skips and CI stays green.

**Live demo** of the same workflow's output (on my fork): https://ttraenkler.github.io/native-messaging-webassembly/

Happy to adjust the host list, sizes, or toolchain versions.